### PR TITLE
Preventive change from <span> to <div> when searching for highlight

### DIFF
--- a/src/lenses/lens-selector-mvp2_HIV.js
+++ b/src/lenses/lens-selector-mvp2_HIV.js
@@ -12,10 +12,10 @@ let annotateHTMLsection = (listOfCategories, enhanceTag) => {
     let response = htmlData;
     listOfCategories.forEach((check) => {
         const rgx = new RegExp(
-            "<span\\s+class\\s*=\\s*[\"']" + check + "[\"']\\s*>",
+            "<div\\s+class\\s*=\\s*[\"']" + check + "[\"']\\s*>",
             "g"
         ); //Only checks one condition every time
-        response = response.replace(rgx, `<span class=\"${check} ${enhanceTag}\">`);
+        response = response.replace(rgx, `<div class=\"${check} ${enhanceTag}\">`);
     });
     //Never return empty section check
     if (response == null || response == "") {

--- a/src/lenses/lens-selector-mvp2_diabetes.js
+++ b/src/lenses/lens-selector-mvp2_diabetes.js
@@ -33,8 +33,8 @@ let  enhance = () => {
    //Focus (adds highlight class) the html applying every category found
    let response = htmlData
    categories.forEach(check => {
-    const rgx = new RegExp('<span\\s+class\\s*=\\s*["\']' + check + '["\']\\s*>', 'g'); //Only checks one condition every time
-    response = response.replace(rgx,`<span class=\"${check} highlight\">`)
+    const rgx = new RegExp('<div\\s+class\\s*=\\s*["\']' + check + '["\']\\s*>', 'g'); //Only checks one condition every time
+    response = response.replace(rgx,`<div class=\"${check} highlight\">`)
    });
    //Never return empty section check
    if (response == null || response == "") {

--- a/src/lenses/lens-selector-mvp2_pregnancy.js
+++ b/src/lenses/lens-selector-mvp2_pregnancy.js
@@ -12,10 +12,10 @@ let annotateHTMLsection = (listOfCategories, enhanceTag) => {
     let response = htmlData;
     listOfCategories.forEach((check) => {
         const rgx = new RegExp(
-            "<span\\s+class\\s*=\\s*[\"']" + check + "[\"']\\s*>",
+            "<div\\s+class\\s*=\\s*[\"']" + check + "[\"']\\s*>",
             "g"
         ); //Only checks one condition every time
-        response = response.replace(rgx, `<span class=\"${check} ${enhanceTag}\">`);
+        response = response.replace(rgx, `<div class=\"${check} ${enhanceTag}\">`);
     });
     //Never return empty section check
     if (response == null || response == "") {


### PR DESCRIPTION
# Announcement

As we talked with @jkiddo, Riccardo and Giussepe on last Thursday's technical meeting, the evolution of the lens requires them to **recognise what to highlight agnostically to the tag type**. This is a preventive change, and **the "definitive" one will come in the few days** (we need to test this well and all the lenses needs to be modified).

If you want to contribute with ideas or feedback, feel free to comment on https://github.com/Gravitate-Health/lens-selector-mvp2/issues/3

Thank you in advance!